### PR TITLE
Fix breakage on Rakudo HEAD

### DIFF
--- a/lib/LibXML/Node/Set.rakumod
+++ b/lib/LibXML/Node/Set.rakumod
@@ -78,7 +78,7 @@ class LibXML::Node::Set
     method string-value { do with $.first { .string-value } // Str}
     multi method to-literal( :list($)! where .so ) { self.map({ .string-value }) }
     multi method to-literal( :delimiter($_) = '' ) { self.to-literal(:list).join: $_ }
-    method Bool { self.defined && self.elems }
+    method Bool { self.defined && so self.elems }
     method Str is also<gist> handles <Int Num trim chomp> { $.Array.map(*.Str).join }
     method is-equiv(LibXML::Node::Set:D $_) { ? $!raw.hasSameNodes(.raw) }
     method reverse {


### PR DESCRIPTION
Not entirely sure whether this is an issue with Rakudo with respect to the new Coercion Protocol, but fact is that this `Bool` method was returning an `Int` rather than a Bool.