### PR TITLE
Assorted performance tweaks

### DIFF
--- a/lib/LibXML/Item.rakumod
+++ b/lib/LibXML/Item.rakumod
@@ -59,7 +59,7 @@ multi sub box-class(Str:D $class-name) {
     }
 }
 
-multi sub box-class(UInt $_) is export(:box-class) {
+multi sub box-class(Int:D $_) is export(:box-class) {
     box-class(@ClassMap[$_] // 'LibXML::Item');
 }
 

--- a/lib/LibXML/Raw/DOM/Document.rakumod
+++ b/lib/LibXML/Raw/DOM/Document.rakumod
@@ -28,7 +28,7 @@ method new-node { ... }
 method getDocumentElement { self.GetRootElement }
 method setDocumentElement(Node $e) { self.SetRootElement($e) }
 
-method createElementNS(Str $URI, QName:D $name is copy) {
+method createElementNS(Str $URI, Str:D $name is copy) {
     return self.createElement($name) without $URI;
     my Str $prefix;
     given $name.split(':', 2) {
@@ -41,11 +41,11 @@ method createElementNS(Str $URI, QName:D $name is copy) {
     self.new-node: :$name, :$ns;
 }
 
-method createElement(QName:D $name) {
+method createElement(Str:D $name) {
     self.new-node: :$name;
 }
 
-method createAttribute(NCName:D $name, Str $value = '') {
+method createAttribute(Str:D $name, Str $value = '') {
     self.domCreateAttribute($name, $value);
 }
 
@@ -61,7 +61,7 @@ multi method adoptNode(Node:D $node) is default {
     self.domImportNode($node, Move, 1);
 }
 
-method createAttributeNS(Str $URI, QName:D $name, Str:D $value = '') {
+method createAttributeNS(Str $URI, Str:D $name, Str:D $value = '') {
     if $URI {
         self.domCreateAttributeNS($URI, $name, $value);
     }

--- a/lib/LibXML/Raw/DOM/Element.rakumod
+++ b/lib/LibXML/Raw/DOM/Element.rakumod
@@ -19,7 +19,7 @@ method domGenNsPrefix { ... }
 
 my subset AttrNode of Node where {!.defined || .type == XML_ATTRIBUTE_NODE};
 
-method setAttribute(QName:D $name, Str:D $value --> UInt) {
+method setAttribute(Str:D $name, Str:D $value --> UInt) {
     if $name ~~ /^xmlns[\:(.*)|$]/ {
         # user wants to set the special attribute for declaring XML namespace ...
 
@@ -56,19 +56,19 @@ method setAttributeNodeNS(AttrNode $att) {
     self.domSetAttributeNodeNS($att);
 }
 
-method getAttributeNode(QName:D $att-name) {
+method getAttributeNode(Str:D $att-name) {
     self.domGetAttributeNode($att-name);
 }
 
-method hasAttribute(QName:D $att-name --> Bool) {
+method hasAttribute(Str:D $att-name --> Bool) {
     self.getAttributeNode($att-name).defined;
 }
 
-method hasAttributeNS(Str $uri, QName:D $att-name --> Bool) {
+method hasAttributeNS(Str $uri, Str:D $att-name --> Bool) {
     ? self.domHasAttributeNS($uri, $att-name);
 }
 
-method removeAttribute(QName:D $attr-name) {
+method removeAttribute(Str:D $attr-name) {
     with self.getAttributeNode($attr-name) {
         .Release; True;
     }
@@ -97,15 +97,15 @@ method removeAttributeNS(Str $uri, Str $attr-name) {
     }
 }
 
-method getAttributeNodeNS(Str $uri, QName:D $att-name --> AttrNode) {
+method getAttributeNodeNS(Str $uri, Str:D $att-name --> AttrNode) {
     self.domGetAttributeNodeNS($uri, $att-name);
 }
 
-method getAttributeNS(Str $uri, QName:D $att-name --> Str) {
+method getAttributeNS(Str $uri, Str:D $att-name --> Str) {
     self.domGetAttributeNS($uri, $att-name);
 }
 
-method getAttribute(QName:D $name) {
+method getAttribute(Str:D $name) {
     if $name ~~ /^xmlns[\:(.*)|$]/ {
         # user wants to get the special attribute for declaring XML namespace ...
 
@@ -120,7 +120,7 @@ method getAttribute(QName:D $name) {
     }
 }
 
-method setAttributeNS(Str $uri, QName:D $name, Str:D $value) {
+method setAttributeNS(Str $uri, Str:D $name, Str:D $value) {
     if $name ~~ /^xmlns[\:|$]/ {
         if $uri !~~ XML_XMLNS_NS {
             fail("NAMESPACE ERROR: Namespace declarations must have the prefix 'xmlns'");

--- a/lib/LibXML/Raw/DOM/Node.rakumod
+++ b/lib/LibXML/Raw/DOM/Node.rakumod
@@ -178,7 +178,7 @@ method appendText(Str:D $text) {
     self.AddContent($text);
 }
 
-method appendTextChild(QName:D $name, Str $text) {
+method appendTextChild(Str:D $name, Str $text) {
     self.domAppendTextChild($name, $text);
 }
 

--- a/lib/LibXML/Types.rakumod
+++ b/lib/LibXML/Types.rakumod
@@ -2,7 +2,7 @@ unit module LibXML::Types;
 
 use XML::Grammar;
 
-subset NCName of Str is export(:NCName) where {!$_ || $_ ~~ /^<XML::Grammar::pident>$/}
-subset QName of Str is export(:QName) where Str:U|/^<XML::Grammar::name>$/;
+subset NCName of Str is export(:NCName) where !.defined || ?XML::Grammar.parse($_, :rule<pident>);
+subset QName of Str is export(:QName) where !.defined || ?XML::Grammar.parse($_, :rule<name>);
 subset NameVal of Pair is export(:NameVal) where .key ~~ QName:D && .value ~~ Str:D;
 

--- a/lib/LibXML/Types.rakumod
+++ b/lib/LibXML/Types.rakumod
@@ -1,8 +1,13 @@
 unit module LibXML::Types;
 
-use XML::Grammar;
+my token pident {
+    <.ident> [ '-' [ \d+ <.ident>? || <.ident> ]* % '-' ]?
+}
 
-subset NCName of Str is export(:NCName) where !.defined || ?XML::Grammar.parse($_, :rule<pident>);
-subset QName of Str is export(:QName) where !.defined || ?XML::Grammar.parse($_, :rule<name>);
+my token name {
+    ^ <pident> [ ':' <pident> ]? $
+}
+
+subset NCName of Str is export(:NCName) where !.defined || /^<pident>$/;
+subset QName of Str is export(:QName) where !.defined || $_ ~~ &name;
 subset NameVal of Pair is export(:NameVal) where .key ~~ QName:D && .value ~~ Str:D;
-


### PR DESCRIPTION
I was recently asked to look in to the performance of `Spreadsheet::XLSX`. Profiling revealed that a significant amount of the overhead was from calls into the `LibXML` module:

![image](https://user-images.githubusercontent.com/50259/102555210-9dcb9800-40c6-11eb-99fe-c8b8d8812d9b.png)

(The blue indicates code that is in the current project - in this case, the `SpreadSheet::XLSX` module. The grey below it is external code, including modules, the Rakudo standard library, and so forth.)

Looking a little more deeply into the hot spots, I produced a number of changes, where are included in this PR. I suggest reviewing the individual commits; in each I wrote the gain and what I perceive as the trade-off of the change, as for the most part I think they need a decision of whether it's an OK thing to do from the perspective of the module architecture.

Between this and one small improvement in `Spreadsheet::XLSX`, I'm currently seeing saving of a large worksheet in around half the time (my benchmark included startup and sheet setup before saving, which is why the improvements in the commits are counted as lower). The vast majority of that is due to these changes, so presumably they'll help others with similar use cases (XML writing) using this module too.