### PR TITLE
Add more thread-safety measures

### DIFF
--- a/lib/LibXML/Config.rakumod
+++ b/lib/LibXML/Config.rakumod
@@ -40,16 +40,18 @@ method have-threads returns Bool { ? xml6_config::have_threads(); }
 #| Returns True if the `libxml2` library supports compression
 method have-compression returns Bool { ? xml6_config::have_compression(); }
 
-our @catalogs;
-method load-catalog(Str:D $filename) {
-    my Int $stat = 0;
-    unless @catalogs.first($filename) {
-        $stat = xmlLoadCatalog($filename);
-        fail "unable to load XML catalog: $filename"
-            if $stat < 0;
-        @catalogs.push: $filename;
+my @catalogs;
+my $catalog-lock = Lock.new;
+method load-catalog(Str:D $filename --> Nil) {
+    $catalog-lock.protect: {
+        my Int $stat = 0;
+        unless @catalogs.first($filename) {
+            $stat = xmlLoadCatalog($filename);
+            fail "unable to load XML catalog: $filename"
+                if $stat < 0;
+            @catalogs.push: $filename;
+        }
     }
-    Mu;
 }
 
 =head2 Serialization Default Options

--- a/lib/LibXML/Item.rakumod
+++ b/lib/LibXML/Item.rakumod
@@ -1,4 +1,3 @@
-our %class;
 
 #| base class for namespaces and nodes
 unit class LibXML::Item;
@@ -27,11 +26,16 @@ use LibXML::Raw;
 use LibXML::Raw::DOM::Node;
 use LibXML::Enums;
 use LibXML::Config;
+
+my %class;
+my $class-lock = Lock.new;
  
 proto sub box-class($) {*}
 multi sub box-class(Str:D $class-name) {
-    given %class{$class-name} {
-        .isa(LibXML::Item) ?? $_ !! ($_ = (require ::($class-name)));
+    $class-lock.protect: {
+        given %class{$class-name} {
+            .isa(LibXML::Item) ?? $_ !! ($_ = (require ::($class-name)));
+        }
     }
 }
 


### PR DESCRIPTION
Change `our` declarations to `my`. They are only referenced locally.

Protect a hash and an array access with locks.