### PR TITLE
Refactor the code to make it more thread-safe

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,21 +1,22 @@
 {
-  "auth": "zef:dwarring",
+  "name": "LibXML",
+  "description": "Raku bindings to the libxml2 native library",
+  "version": "0.6.14",
+  "perl": "6",
   "authors": [
     "David Warring"
   ],
-  "build-depends": [
-    "LibraryMake"
-  ],
+  "auth": "zef:dwarring",
   "depends": [
     "File::Temp",
     "Method::Also",
     "W3C::DOM:ver<0.0.2+>",
     "XML"
   ],
-  "description": "Raku bindings to the libxml2 native library",
-  "license": "Artistic-2.0",
-  "name": "LibXML",
-  "perl": "6",
+  "build-depends": [
+    "LibraryMake"
+  ],
+  "test-depends": [],
   "provides": {
     "LibXML": "lib/LibXML.rakumod",
     "LibXML::Attr": "lib/LibXML/Attr.rakumod",
@@ -72,6 +73,7 @@
     "LibXML::Schema": "lib/LibXML/Schema.rakumod",
     "LibXML::Text": "lib/LibXML/Text.rakumod",
     "LibXML::Types": "lib/LibXML/Types.rakumod",
+    "LibXML::Utils": "lib/LibXML/Utils.pm6",
     "LibXML::XPath::Context": "lib/LibXML/XPath/Context.rakumod",
     "LibXML::XPath::Expression": "lib/LibXML/XPath/Expression.rakumod",
     "LibXML::XPath::Object": "lib/LibXML/XPath/Object.rakumod",
@@ -85,17 +87,16 @@
     "libraries/xml6",
     "libraries/libxml2"
   ],
-  "source-url": "https://github.com/libxml-raku/LibXML-raku.git",
   "support": {
     "source": "https://github.com/libxml-raku/LibXML-raku.git"
   },
+  "license": "Artistic-2.0",
   "tags": [
     "xml",
     "html",
     "xpath",
     "dom"
   ],
-  "test-depends": [
-  ],
-  "version": "0.6.14"
+  "source-url": "https://github.com/libxml-raku/LibXML-raku.git",
+  "raku": "*"
 }

--- a/META6.json
+++ b/META6.json
@@ -12,7 +12,7 @@
     "Method::Also",
     "W3C::DOM:ver<0.0.2+>",
     "XML",
-    "AttrX::Mooish:ver<0.8.4+>:auth:<zef:vrurg>"
+    "AttrX::Mooish:ver<0.8.4+>:auth<zef:vrurg>"
   ],
   "build-depends": [
     "LibraryMake"

--- a/META6.json
+++ b/META6.json
@@ -11,7 +11,8 @@
     "File::Temp",
     "Method::Also",
     "W3C::DOM:ver<0.0.2+>",
-    "XML"
+    "XML",
+    "AttrX::Mooish:ver<0.8.4+>:auth:<zef:vrurg>"
   ],
   "build-depends": [
     "LibraryMake"
@@ -73,7 +74,7 @@
     "LibXML::Schema": "lib/LibXML/Schema.rakumod",
     "LibXML::Text": "lib/LibXML/Text.rakumod",
     "LibXML::Types": "lib/LibXML/Types.rakumod",
-    "LibXML::Utils": "lib/LibXML/Utils.pm6",
+    "LibXML::Utils": "lib/LibXML/Utils.rakumod",
     "LibXML::XPath::Context": "lib/LibXML/XPath/Context.rakumod",
     "LibXML::XPath::Expression": "lib/LibXML/XPath/Expression.rakumod",
     "LibXML::XPath::Object": "lib/LibXML/XPath/Object.rakumod",

--- a/lib/LibXML/Config.rakumod
+++ b/lib/LibXML/Config.rakumod
@@ -48,16 +48,16 @@ method have-threads returns Bool { ? xml6_config::have_threads(); }
 #| Returns True if the `libxml2` library supports compression
 method have-compression returns Bool { ? xml6_config::have_compression(); }
 
-my @catalogs;
+my $catalogs = SetHash.new;
 my $catalog-lock = Lock.new;
 method load-catalog(Str:D $filename --> Nil) {
     $catalog-lock.protect: {
         my Int $stat = 0;
-        unless @catalogs.first($filename) {
+        unless $filename ∈ $catalogs {
             $stat = xmlLoadCatalog($filename);
             fail "unable to load XML catalog: $filename"
                 if $stat < 0;
-            @catalogs.push: $filename;
+            $catalogs.set: $filename;
         }
     }
 }

--- a/lib/LibXML/Config.rakumod
+++ b/lib/LibXML/Config.rakumod
@@ -10,21 +10,29 @@ unit class LibXML::Config;
 
 use LibXML::Enums;
 use LibXML::Raw;
+use LibXML::Types :resolve-package;
 use NativeCall;
+use AttrX::Mooish;
 
 =head2 Configuration Methods
 
 #| Returns the run-time version of the `libxml2` library.
+my $version;
 method version returns Version {
-    state $ //= Version.new(xmlParserVersion.match(/^ (.) (..) (..) /).join: '.');
+    return $_ with ⚛$version;
+    cas $version, { $_ // Version.new(xmlParserVersion.match(/^ (.) (..) (..) /).join: '.') };
 }
 
 #| Returns the version of the `libxml2` library that the LibXML module was built against
-method config-version { Version.new: xml6_config::version(); }
+my $config-version;
+method config-version {
+    return $_ with ⚛$config-version;
+    cas $config-version, { $_ // Version.new: xml6_config::version() }
+}
 
 #| Returns True if the `libxml2` library supports XML Reader (LibXML::Reader) functionality.
 method have-reader returns Bool {
-    (require ::('LibXML::Reader')).have-reader
+    resolve-package('LibXML::Reader').have-reader
 }
 
 #| Returns True if the `libxml2` library supports XML Schema (LibXML::Schema) functionality.
@@ -56,19 +64,29 @@ method load-catalog(Str:D $filename --> Nil) {
 
 =head2 Serialization Default Options
 
-our $inputCallbacks;
+my $inputCallbacks;
 
 # -- Output options --
 
-our $skipXMLDeclaration = Bool;
-our $skipDTD = Bool;
-our $maxErrors = 100;
+my Bool:D $skipXMLDeclaration = False;
+my Bool:D $skipDTD = False;
+my Int:D $maxErrors = 100;
 
 #| Whether to omit '<?xml ...>' preamble (default Fallse)
-method skip-xml-declaration returns Bool is rw { flag-proxy($skipXMLDeclaration) }
+has Bool:D $!skipXMLDeclaration is mooish(:lazy);
+method !build-skipXMLDeclaration { $skipXMLDeclaration }
+
+proto method skip-xml-declaration() {*}
+multi method skip-xml-declaration(::?CLASS:U: --> Bool) is rw { flag-proxy($skipXMLDeclaration) }
+multi method skip-xml-declaration(::?CLASS:D: --> Bool) is rw { flag-proxy($!skipXMLDeclaration) }
 
 #| Whether to omit internal DTDs (default False)
-method skip-dtd returns Bool is rw { flag-proxy($skipDTD) }
+has Bool:D $!skipDTD is mooish(:lazy);
+method !build-skipDTD { $skipDTD }
+
+proto method skip-dtd() {*}
+multi method skip-dtd(::?CLASS:U: --> Bool) is rw { flag-proxy($skipDTD) }
+multi method skip-dtd(::?CLASS:D: --> Bool) is rw { flag-proxy($!skipDTD) }
 
 #| Whether to output empty tags as '<a></a>' rather than '<a/>' (default False)
 method tag-expansion is rw returns Bool {
@@ -76,15 +94,18 @@ method tag-expansion is rw returns Bool {
 }
 
 #| Maximum errors before throwing a fatal X::LibXML::TooManyErrors
-method max-errors is rw returns UInt:D {
-    $maxErrors;
-}
+has UInt:D $!maxErrors is mooish(:lazy);
+method !build-maxErrors { $maxErrors }
+
+proto method max-errors() {*}
+multi method max-errors(::?CLASS:U: --> UInt:D) is rw { $maxErrors }
+multi method max-errors(::?CLASS:D: --> UInt:D) is rw { $!maxErrors }
 
 =head2 Parsing Default Options
 
 sub flag-proxy($flag is rw) is rw {
     Proxy.new( FETCH => sub ($) { $flag.so },
-               STORE => sub ($, $_) { $flag = .so } ); 
+               STORE => sub ($, $_) { $flag = .so } );
 }
 
 method keep-blanks-default is rw is DEPRECATED<keep-blanks> { $.keep-blanks }
@@ -163,13 +184,21 @@ method external-entity-loader returns Callable is rw {
         =end code
 
 #| Default input callback handlers
-method input-callbacks is rw {
+has $!inputCallbacks is mooish(:lazy);
+method !build-inputCallbacks { $inputCallbacks }
+
+proto method input-callbacks(|) {*}
+multi method input-callbacks(::?CLASS:U:) is rw {
     Proxy.new(
         FETCH => sub ($) { $inputCallbacks },
-        STORE => sub ($, $callbacks) {
-            $inputCallbacks = $callbacks;
-        }
+        STORE => sub ($, $callbacks) { $inputCallbacks = $callbacks }
     );
+}
+multi method input-callbacks(::?CLASS:D:) is rw {
+    Proxy.new(
+        FETCH => sub ($) { $!inputCallbacks },
+        STORE => sub ($, $callbacks) { $!inputCallbacks = $callbacks }
+        );
 }
 =para See L<LibXML::InputCallback>
 
@@ -177,7 +206,7 @@ method input-callbacks is rw {
 
 my subset QueryHandler where .can('query-to-xpath').so;
 
-our $queryHandler = class NoQueryHandler {
+my $queryHandler = class NoQueryHandler {
     method query-to-xpath($) {
         fail "queryHandler has not been configured";
     }
@@ -189,13 +218,21 @@ method lock handles<protect> {
 }
 
 #| Default query handler to service querySelector() and querySelectorAll() methods
-method query-handler returns QueryHandler is rw {
+has $!queryHandler is mooish(:lazy);
+method !build-queryHandler { $queryHandler }
+
+proto method query-handler() {*}
+multi method query-handler(::?CLASS:U: --> QueryHandler) is rw {
     Proxy.new(
         FETCH => sub ($) { $queryHandler },
-        STORE => sub ($, QueryHandler $_) {
-            $queryHandler = $_;
-        }
+        STORE => sub ($, QueryHandler $_) { $queryHandler = $_; }
     );
+}
+multi method query-handler(::?CLASS:D: --> QueryHandler) is rw {
+    Proxy.new(
+        FETCH => sub ($) { $!queryHandler },
+        STORE => sub ($, QueryHandler $_) { $!queryHandler = $_; }
+        );
 }
 =para See L<LibXML::XPath::Context>
 

--- a/lib/LibXML/Document.rakumod
+++ b/lib/LibXML/Document.rakumod
@@ -19,11 +19,11 @@ use LibXML::Element;
 use LibXML::EntityRef;
 use LibXML::Enums;
 use LibXML::Item :dom-boxed;
-use LibXML::Node :&output-options;
+use LibXML::Utils :&output-options;
 use LibXML::Raw;
 use LibXML::PI;
 use LibXML::Text;
-use LibXML::Types :QName, :NCName, :NameVal;
+use LibXML::Types :QName, :NCName, :NameVal, :resolve-package;
 use LibXML::_Validator;
 use Method::Also;
 use NativeCall;
@@ -174,9 +174,7 @@ method new(
 
 =end pod
 
-method implementation returns W3C::DOM::Implementation {
-    require ::('LibXML');
-}
+method implementation returns W3C::DOM::Implementation { resolve-package('LibXML') }
 
 # Perl compatibility
 multi method createDocument(Str:D() $version where /^\d'.'\d$/, xmlEncodingStr $enc) {
@@ -854,7 +852,7 @@ method externalSubset is rw returns LibXML::Dtd {
              );
 }
 
-method parser handles<parse parseFromString> { require ::('LibXML::Parser'); }
+method parser handles<parse parseFromString> { resolve-package('LibXML::Parser'); }
 =begin pod
     =head3 method parse
 

--- a/lib/LibXML/Element.rakumod
+++ b/lib/LibXML/Element.rakumod
@@ -1,13 +1,15 @@
-use LibXML::Node :&iterate-list;
+
+#| LibXML Class for Element Nodes
+unit class LibXML::Element is repr('CPointer');
+
+use LibXML::Node;
+use LibXML::Utils :iterate-list;
 use LibXML::_ParentNode;
 use W3C::DOM;
 
-#| LibXML Class for Element Nodes
-unit class LibXML::Element
-    is repr('CPointer')
-    is LibXML::Node
-    does LibXML::_ParentNode
-    does W3C::DOM::Element;
+also is LibXML::Node;
+also does LibXML::_ParentNode;
+also does W3C::DOM::Element;
 
 =begin pod
     =head2 Synopsis

--- a/lib/LibXML/HashMap.rakumod
+++ b/lib/LibXML/HashMap.rakumod
@@ -5,12 +5,13 @@ unit class LibXML::HashMap
 
 use LibXML::Item;
 use LibXML::Node::Set;
-use LibXML::XPath::Object :XPathRange;
+use LibXML::Types :XPathRange;
 use LibXML::Raw;
 use LibXML::Raw::Defs :$XML2, :$CLIB, :xmlCharP;
 use LibXML::Raw::HashTable;
 use LibXML::Enums;
 use LibXML::Dtd::Notation;
+use LibXML::XPath::Object;
 use NativeCall;
 use Method::Also;
 

--- a/lib/LibXML/Item.rakumod
+++ b/lib/LibXML/Item.rakumod
@@ -1,4 +1,3 @@
-
 #| base class for namespaces and nodes
 unit class LibXML::Item;
 
@@ -26,24 +25,20 @@ use LibXML::Raw;
 use LibXML::Raw::DOM::Node;
 use LibXML::Enums;
 use LibXML::Config;
+use LibXML::Types :resolve-package;
 
-my %class;
-my $class-lock = Lock.new;
- 
+also does LibXML::Types::XPathish;
+
 proto sub box-class($) {*}
 multi sub box-class(Str:D $class-name) {
-    $class-lock.protect: {
-        given %class{$class-name} {
-            .isa(LibXML::Item) ?? $_ !! ($_ = (require ::($class-name)));
-        }
-    }
+    resolve-package($class-name)
 }
 
 multi sub box-class(Int:D $_) is export(:box-class) {
     box-class(@LibXML::Config::ClassMap[$_]);
 }
 
-multi sub box-class(LibXML::Item $_) { $_ }
+multi sub box-class(::?CLASS $_) { $_ }
 
 multi method box($_) {
     .defined ?? box-class(.type).box(.delegate) !! self.WHAT;

--- a/lib/LibXML/Node.rakumod
+++ b/lib/LibXML/Node.rakumod
@@ -1,14 +1,24 @@
 use v6;
-use LibXML::Item :box-class, :ast-to-xml;
-use LibXML::_DomNode;
-use W3C::DOM;
 
 #| Abstract base class of LibXML Nodes
-unit class LibXML::Node
-    is repr('CPointer')
-    is LibXML::Item
-    does LibXML::_DomNode
-    does W3C::DOM::Node;
+unit class LibXML::Node is repr('CPointer');
+
+use LibXML::Item :box-class, :ast-to-xml, :dom-boxed;
+use LibXML::_DomNode;
+use LibXML::Config;
+use LibXML::Enums;
+use LibXML::Namespace;
+use LibXML::Raw;
+use LibXML::XPath::Expression;
+use LibXML::Types :NCName, :QName;
+use LibXML::Utils :iterate-list, :iterate-set, :output-options;
+use W3C::DOM;
+use NativeCall;
+use Method::Also;
+
+also is LibXML::Item;
+also does LibXML::_DomNode;
+also does W3C::DOM::Node;
 
 =begin pod
 
@@ -119,16 +129,6 @@ unit class LibXML::Node
 
     Many methods listed here are extensively documented in the DOM Level 3 specification (L<http://www.w3.org/TR/DOM-Level-3-Core/>). Please refer to the specification for extensive documentation.
 =end pod
-use Method::Also;
-use NativeCall;
-
-use LibXML::Raw;
-use LibXML::Config;
-use LibXML::Enums;
-use LibXML::Namespace;
-use LibXML::XPath::Expression;
-use LibXML::Types :NCName, :QName;
-use LibXML::Item :dom-boxed;
 
 constant config = LibXML::Config;
 my subset NameVal of Pair is export(:NameVal) where .key ~~ QName:D && .value ~~ Str:D;
@@ -309,7 +309,7 @@ method prev returns LibXML::Node is dom-boxed {...}
 
 # Fallback to LibXML::Attr::Map:U for non-element nodes
 method attributes(LibXML::Node:D $node:) {
-    require ::('LibXML::Attr::Map')
+    box-class('LibXML::Attr::Map')
 }
 
 =begin pod
@@ -529,9 +529,7 @@ method insertAfter(LibXML::Node:D $new, LibXML::Node $ref? --> LibXML::Node) {
 ########################################################################
 =head2 Searching Methods
 
-method xpath-class {
-    require ::('LibXML::XPath::Context');
-}
+method xpath-class { box-class('LibXML::XPath::Context') }
 
 method xpath-context($node: |c) {
     $.xpath-class.new: :$node, |c;
@@ -724,16 +722,6 @@ method exists(XPathExpr $expr, LibXML::Node:D $node = self, :%ns) {
     See L<LibXML::XPath::Context> for more details.
 =end pod
 
-sub iterate-list($parent, $of, Bool :$blank = True) is export(:iterate-list) {
-    # follow a chain of .next links.
-    (require ::('LibXML::Node::List')).new: :$of, :$blank, :$parent;
-}
-
-sub iterate-set($of, xmlNodeSet $raw, Bool :$deref) is export(:iterate-set) {
-    # iterate through a set of nodes
-    (require ::('LibXML::Node::Set')).new( :$raw, :$of, :$deref );
-}
-
 multi method ACCEPTS(LibXML::Node:D: LibXML::XPath::Expression:D $expr) {
     $.xpath-context.exists($expr);
 }
@@ -893,25 +881,6 @@ multi method save(IO() :io($path)!, |c) {
 
 multi method save(IO() :file($io)!, |c) {
     $.save(:$io, |c).close;
-}
-
-sub output-options(UInt :$options is copy = 0,
-                   Bool :$format,
-                   Bool :$skip-xml-declaration = config.skip-xml-declaration,
-                   Bool :$tag-expansion = config.tag-expansion,
-                   # **DEPRECATED**
-                   Bool :$skip-decl, Bool :$expand,
-                  ) is export(:output-options) {
-
-    warn ':skip-decl option is deprecated, please use :skip-xml-declaration'
-        with $skip-decl;
-    warn ':expand option is deprecated, please use :tag-expansion'
-        with $expand;
-    for $format => XML_SAVE_FORMAT, $skip-xml-declaration => XML_SAVE_NO_DECL, $tag-expansion =>  XML_SAVE_NO_EMPTY {
-        $options +|= .value if .key;
-    }
-
-    $options;
 }
 
 method protect(&action) {

--- a/lib/LibXML/Raw/DOM/Node.rakumod
+++ b/lib/LibXML/Raw/DOM/Node.rakumod
@@ -230,7 +230,6 @@ method domCheck(Bool :$recursive = True, :%seen = %(), :@path = [0]) {
 
     my Node $last;
     my Node $kid = self.children;
-    my $is-doc = ? (self.type == XML_DOCUMENT_NODE|XML_HTML_DOCUMENT_NODE|XML_DOCB_DOCUMENT_NODE);
     my @subpath = @path;
     @subpath.push: 0;
     my %kids-seen;

--- a/lib/LibXML/Types.rakumod
+++ b/lib/LibXML/Types.rakumod
@@ -11,3 +11,12 @@ my token name {
 subset NCName of Str is export(:NCName) where !.so || /^<pident>$/;
 subset QName of Str is export(:QName) where !.defined || $_ ~~ &name;
 subset NameVal of Pair is export(:NameVal) where .key ~~ QName:D && .value ~~ Str:D;
+
+# XPathish is just a marker role for classes matching XPathRange
+role XPathish {}
+subset XPathRange is export(:XPathRange) where Bool|Numeric|Str|XPathish;
+
+my $resolve-lock = Lock.new;
+sub resolve-package(Str:D $pkg) is export(:resolve-package) is raw {
+    $resolve-lock.protect: { ::{$pkg}:exists ?? ::($pkg) !! do require ::($pkg) }
+}

--- a/lib/LibXML/Utils.rakumod
+++ b/lib/LibXML/Utils.rakumod
@@ -1,0 +1,35 @@
+unit module LibXML::Utils;
+use LibXML::Node::List;
+use LibXML::Node::Set;
+use LibXML::Raw;
+use LibXML::Enums;
+use LibXML::Config;
+
+sub iterate-list($parent, $of, Bool :$blank = True) is export(:iterate-list) {
+    # follow a chain of .next links.
+    LibXML::Node::List.new: :$of, :$blank, :$parent;
+}
+
+sub iterate-set($of, xmlNodeSet $raw, Bool :$deref) is export(:iterate-set) {
+    # iterate through a set of nodes
+    LibXML::Node::Set.new( :$raw, :$of, :$deref );
+}
+
+sub output-options(UInt :$options is copy = 0,
+                   Bool :$format,
+                   Bool :$skip-xml-declaration = LibXML::Config.skip-xml-declaration,
+                   Bool :$tag-expansion = LibXML::Config.tag-expansion,
+    # **DEPRECATED**
+                   Bool :$skip-decl, Bool :$expand,
+                   ) is export(:output-options) {
+
+    warn ':skip-decl option is deprecated, please use :skip-xml-declaration'
+    with $skip-decl;
+    warn ':expand option is deprecated, please use :tag-expansion'
+    with $expand;
+    for $format => XML_SAVE_FORMAT, $skip-xml-declaration => XML_SAVE_NO_DECL, $tag-expansion =>  XML_SAVE_NO_EMPTY {
+        $options +|= .value if .key;
+    }
+
+    $options;
+}

--- a/lib/LibXML/XPath/Context.rakumod
+++ b/lib/LibXML/XPath/Context.rakumod
@@ -108,12 +108,13 @@ use LibXML::Document;
 use LibXML::Item;
 use LibXML::Raw;
 use LibXML::Namespace;
-use LibXML::Node :iterate-set, :NameVal;
+use LibXML::Utils :iterate-set;
+use LibXML::Node :NameVal;
 use LibXML::Node::List;
 use LibXML::Node::Set;
-use LibXML::Types :NCName, :QName;
+use LibXML::Types :NCName, :QName, :XPathRange;
 use LibXML::XPath::Expression;
-use LibXML::XPath::Object :XPathRange;
+use LibXML::XPath::Object;
 use NativeCall;
 use Method::Also;
 

--- a/lib/LibXML/XPath/Object.rakumod
+++ b/lib/LibXML/XPath/Object.rakumod
@@ -4,9 +4,11 @@ unit class LibXML::XPath::Object
 
 use LibXML::Item;
 use LibXML::Raw;
-use LibXML::Node :iterate-set;
-use LibXML::Node::Set;
+use LibXML::Utils :iterate-set;
+use LibXML::Types :XPathRange;
 use NativeCall;
+
+also does LibXML::Types::XPathish;
 
 method new(xmlXPathObject:D :$raw!) {
     $raw.Reference;
@@ -17,11 +19,9 @@ method raw { nativecast(xmlXPathObject, self) }
 
 submethod DESTROY { self.raw.Unreference }
 
-my subset XPathRange is export(:XPathRange) where Bool|Numeric|Str|LibXML::Node::Set|LibXML::Item;
-
 method coerce-to-raw(XPathRange $content is copy) {
     $content .= raw()
-        if $content ~~ LibXML::Item|LibXML::Node::Set;
+        if $content ~~ LibXML::Types::XPathish;
     xmlXPathObject.coerce($content);
 }
 

--- a/lib/LibXML/_ParentNode.rakumod
+++ b/lib/LibXML/_ParentNode.rakumod
@@ -1,9 +1,11 @@
 #| methods common to elements, documents and document fragments
 unit role LibXML::_ParentNode;
 
-use LibXML::Node :iterate-set;
-use LibXML::Types :QName, :NameVal;
+use LibXML::Node;
 use LibXML::Config;
+use LibXML::Types :QName, :NameVal;
+use LibXML::Utils :iterate-set;
+
 my constant config = LibXML::Config;
 
 method getElementsByTagName(Str:D $name) {

--- a/t/00hash-object.t
+++ b/t/00hash-object.t
@@ -2,7 +2,7 @@ use v6;
 use Test;
 use LibXML::HashMap;
 use LibXML::Element;
-use LibXML::XPath::Object :XPathRange;
+use LibXML::Types :XPathRange;
 use NativeCall;
 
 plan 2;


### PR DESCRIPTION
The primary focus is to get rid of bare uses of `require` which sometimes leaks `VMNull` into userland due to race condition. Runtime module loading is now done via `require-package` sub.

Another case covered is `$!hstore` attributes of `LibXML::Node::Set` and `LibXML::Node::List`. These are now lazy-initialized and reset using atomic operations.