### PR TITLE
Minor threading fixes

### DIFF
--- a/lib/LibXML/InputCallback.rakumod
+++ b/lib/LibXML/InputCallback.rakumod
@@ -177,7 +177,7 @@ my class Context {
         -> Pointer $addr, CArray $out-arr, UInt $bytes --> UInt {
             CATCH { default { self!catch($_); 0; } }
 
-            my Handle $handle = %!handles{+$addr}
+            my Handle $handle = $!lock.protect({ %!handles{+$addr} })
                 // die "read on unopen handle";
 
             given $handle.buf // $!cb.read.($handle.fh, $bytes) -> Blob $io-buf is copy {


### PR DESCRIPTION
Fix a race on accessing `%!handles`.

Also, `require` and `Stash` are now thread-safe (or much safer at least ;) ). Hence, the `lock.protect` around them is not needed anymore. But the compatibility with older Rakudo releases requires it to remain in place. To solve this contradiction I replaced `resolve-package` sub with a variable and initialize it with actual code depending on the current compiler version.