### PR TITLE
Bump version and add api version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,4 +43,4 @@ jobs:
           zef build .
           zef install --/test App::Prove6
       - name: Run Tests
-        run: prove6 -I. t
+        run: prove6 -I. t xt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Dependencies
         run: |
           zef install --/test LibraryMake
-          zef install --deps-only .
+          zef install --deps-only --test-depends .
           zef build .
           zef install --/test App::Prove6
       - name: Run Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Dependencies
         run: |
           zef install --/test LibraryMake
-          zef install --deps-only --test-depends .
+          zef install --deps-only .
           zef build .
           zef install --/test App::Prove6
       - name: Run Tests

--- a/META6.json
+++ b/META6.json
@@ -18,7 +18,9 @@
   "build-depends": [
     "LibraryMake"
   ],
-  "test-depends": [],
+  "test-depends": [
+    "JSON::Fast"
+  ],
   "provides": {
     "LibXML": "lib/LibXML.rakumod",
     "LibXML::Attr": "lib/LibXML/Attr.rakumod",

--- a/META6.json
+++ b/META6.json
@@ -2,7 +2,7 @@
   "name": "LibXML",
   "description": "Raku bindings to the libxml2 native library",
   "version": "0.8.0",
-  "api: "0.8.0",
+  "api": "0.8.0",
   "perl": "6",
   "authors": [
     "David Warring"

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,8 @@
 {
   "name": "LibXML",
   "description": "Raku bindings to the libxml2 native library",
-  "version": "0.7.10",
+  "version": "0.8.0",
+  "api: "0.8.0",
   "perl": "6",
   "authors": [
     "David Warring"

--- a/lib/LibXML.rakumod
+++ b/lib/LibXML.rakumod
@@ -4,7 +4,7 @@ use W3C::DOM;
 # Needed for Rakudo 2020.5.1 - see #59
 use LibXML::XPath::Context;
 
-unit class LibXML:ver<0.8.0>:api<0.8.0>
+unit class LibXML:ver<0.7.10>
     is LibXML::Parser
     does W3C::DOM::Implementation;
 

--- a/lib/LibXML.rakumod
+++ b/lib/LibXML.rakumod
@@ -4,7 +4,7 @@ use W3C::DOM;
 # Needed for Rakudo 2020.5.1 - see #59
 use LibXML::XPath::Context;
 
-unit class LibXML:ver<0.7.10>
+unit class LibXML:ver<0.8.0>:api<0.8.0>
     is LibXML::Parser
     does W3C::DOM::Implementation;
 

--- a/xt/release/version.t
+++ b/xt/release/version.t
@@ -1,0 +1,30 @@
+use LibXML;
+use Test;
+use JSON::Fast;
+
+plan 2;
+
+my %META6 = from-json "META6.json".IO.slurp;
+my Version:D() $ver = LibXML.^ver;
+
+subtest 'LibXML.^ver', {
+    ok $ver, 'is Trueish';
+    my @parts = $ver.Str.split: '.';
+
+    is +@parts, 3, 'is semantic (X.Y.Z)';
+    is-deeply ~$ver, %META6<version>, "consistant with META6<version>"
+        or diag "Mismatch between LibXML.^ver({LibXML.^ver.raku}) and META6<version>({%META6<version>.raku})"
+}
+
+subtest 'LibXML.^api', {
+    my Version:D() $api = LibXML.^api;
+    ok $api, 'is Trueish';
+    my @parts = $api.Str.split: '.';
+
+    ok 2 <= +@parts <= 3, 'is of form X.Y[.Z]';
+    my $ver-base = Version.new('v' ~ $ver.parts[0..*-2].join('.')~'.0');
+    ok $ver-base <= $api <= $ver, "api within range ($ver-base <= $api <= $ver)";
+
+    is-deeply ~$api, %META6<api>, "consistant with META6<api>"
+        or diag "Mismatch between LibXML.^api({LibXML.^api.raku}) and META6<api>({%META6<api>.raku})";
+}


### PR DESCRIPTION
I decided this would serve as a good reminder to remember to add `api` version to `META6.json` because the change worth reflecting it this way.

I don't actually propose this exact `api` version. This is just my habbit to number them after the module version. Many choose a plain integer like 1, 2, etc. 