### PR TITLE
Simplify subclassing in complex cases

### DIFF
--- a/lib/LibXML/Config.rakumod
+++ b/lib/LibXML/Config.rakumod
@@ -442,8 +442,8 @@ multi method map-class(::?CLASS:D: *@pos, *%mappings) {
 }
 
 proto method class-from($) {*}
-multi method class-from(::?CLASS:U: |c) { $singleton.class-from(|c) }
-multi method class-from(::?CLASS:D: LibXML::Types::Itemish:U \from-type, Bool:D :$strict = True) {
+multi method class-from(::?CLASS:U: |c) is raw { $singleton.class-from(|c) }
+multi method class-from(::?CLASS:D: LibXML::Types::Itemish:U \from-type, Bool:D :$strict = True) is raw {
     return from-type
         unless self!validate-map-class(
             from-type,
@@ -451,7 +451,7 @@ multi method class-from(::?CLASS:D: LibXML::Types::Itemish:U \from-type, Bool:D 
             :$strict);
     samewith(%DefaultClassMap{from-type.^name});
 }
-multi method class-from(::?CLASS:D: Str:D $class, Bool:D :$strict = True) {
+multi method class-from(::?CLASS:D: Str:D $class, Bool:D :$strict = True) is raw {
     return resolve-package($class)
         unless self!validate-map-class-name(
             $class,
@@ -459,7 +459,8 @@ multi method class-from(::?CLASS:D: Str:D $class, Bool:D :$strict = True) {
             :$strict);
     samewith(%DefaultClassMap{$class});
 }
-multi method class-from(::?CLASS:D: Int:D $id) { @.class-map[$id] }
+multi method class-from(::?CLASS:D: Int:D $id) is raw { @.class-map[$id] }
+multi method class-from(::?CLASS:D: anyNode:D $raw) is raw { @.class-map[$raw.type] }
 
 =begin pod
 

--- a/lib/LibXML/Node.rakumod
+++ b/lib/LibXML/Node.rakumod
@@ -165,7 +165,7 @@ submethod DESTROY {
 
 multi method box(anyNode:D $node, *%c) {
     $node.Reference;
-    my $class := (%c<config> //= self.config).class-map[$node.type];
+    my $class := (%c<config> //= self.config).class-from($node);
     $class.bless: :raw($node.delegate), |%c;
 }
 

--- a/t/00subclass.t
+++ b/t/00subclass.t
@@ -1,5 +1,5 @@
 use Test;
-plan 11;
+plan 2;
 
 # Experimental. This may change without notice.
 # Testing the current ability of Raku LibXML to define custom node classes:
@@ -14,10 +14,18 @@ use LibXML::Document;
 use LibXML::Element;
 use LibXML::Attr;
 use LibXML::Raw;
+use LibXML::Types;
+use OO::Monitors;
 
 class MyElement is LibXML::Element {
     has Str:D $.my-attr = "something special";
     method nodeValue { 'bazinga' }
+}
+
+class MyElement::Foo is MyElement {
+    method bar {
+        self.getAttribute('bar')
+    }
 }
 
 class MyAttr is LibXML::Attr {
@@ -27,34 +35,63 @@ class MyAttr is LibXML::Attr {
 #    }
 }
 
-my $config = LibXML::Config.new;
-$config.map-class(
-    'LibXML::Element' => MyElement,
-    (LibXML::Attr) => MyAttr );
+subtest "Basics" => {
+    plan 11;
+    my $config = LibXML::Config.new;
+    $config.map-class(
+        'LibXML::Element' => MyElement,
+        (LibXML::Attr) => MyAttr );
 
-my LibXML::Document:D $doc .= parse: :string(q:to<END>), :$config;
-<doc att="42">test</doc>
-END
+    my LibXML::Document:D $doc .= parse: :string(q:to<END>), :$config;
+    <doc att="42">test</doc>
+    END
 
-my $root = $doc.getDocumentElement;
+    my $root = $doc.getDocumentElement;
 
-isa-ok $root, MyElement, 'parsed elem type';
-isa-ok $root.raw, xmlElem, 'parsed element $.raw type';
-ok defined($root.raw), 'parsed element $.raw is defined';
-is $root.nodeName, 'doc', 'parsed elem name';
-is $root.nodeValue, 'bazinga', 'parsed elem value';
+    isa-ok $root, MyElement, 'parsed elem type';
+    isa-ok $root.raw, xmlElem, 'parsed element $.raw type';
+    ok defined($root.raw), 'parsed element $.raw is defined';
+    is $root.nodeName, 'doc', 'parsed elem name';
+    is $root.nodeValue, 'bazinga', 'parsed elem value';
 
-my $attr = $root.getAttributeNode("att");
+    my $attr = $root.getAttributeNode("att");
 
-isa-ok $attr, MyAttr, 'element attribute type';
-isa-ok $attr.raw, xmlAttr, 'element attribute $.raw type';
+    isa-ok $attr, MyAttr, 'element attribute type';
+    isa-ok $attr.raw, xmlAttr, 'element attribute $.raw type';
 
-my $elem = $doc.createElement('foo');
+    my $elem = $doc.createElement('foo');
 
-isa-ok $elem, MyElement, 'created elem type';
-is $elem.nodeName, 'foo', 'created elem name';
-is $elem.nodeValue, 'bazinga', 'created elem value';
+    isa-ok $elem, MyElement, 'created elem type';
+    is $elem.nodeName, 'foo', 'created elem name';
+    is $elem.nodeValue, 'bazinga', 'created elem value';
 
-$root.addChild($elem);
+    $root.addChild($elem);
 
-is $root.Str, '<doc att="42">test<foo/></doc>', 'serialization sanity';
+    is $root.Str, '<doc att="42">test<foo/></doc>', 'serialization sanity';
+}
+
+subtest "By Element Type" => {
+    plan 4;
+    my monitor MyConfig is LibXML::Config {
+        proto method class-from(|) {*}
+        multi method class-from(::?CLASS:D: anyNode:D $raw) is raw {
+            $raw.getNodeName eq 'foo' ?? MyElement::Foo !! nextsame
+        }
+        multi method class-from(|) is raw { nextsame }
+    }
+
+    my $config = MyConfig.new;
+    $config.map-class('LibXML::Element' => MyElement);
+    my LibXML::Document:D $doc .= parse: :string(q:to<END>), :$config;
+    <doc><foo bar="The Answer" /></doc>
+    END
+
+    isa-ok $doc.config, MyConfig, "document config class";
+
+    my $root = $doc.getDocumentElement;
+
+    isa-ok $root, MyElement, "root element";
+    my $foo = $root.findnodes(q«//foo»).head;
+    isa-ok $foo, MyElement::Foo, "subelement type";
+    is $foo.bar, "The Answer", "attribute reader method";
+}


### PR DESCRIPTION
If there is a need from a registered subclass to not just override an original `LibXML::` class one-to-one, but map into a set of child classes depending on node's content (name, attribute value, etc.) then previously the only valid way was to override `bless` method because boxing were mostly done through `LibXML::Node` `box` method. Now it would be easier by inheriting from `LibXML::Config` and adding a custom `class-from` method.

See t/00subclass.t