### PR TITLE
Make LibXML::Item use :config for boxing

### DIFF
--- a/lib/LibXML/Item.rakumod
+++ b/lib/LibXML/Item.rakumod
@@ -50,8 +50,8 @@ multi method box-class(::?CLASS:D: Int:D $id) { $!config.class-from($id) }
 
 proto method box(|) {*}
 # XXX Should it be `anyNode:D` instead of `Any:D`??
-multi method box(::?CLASS:D: Any:D $_, *%c) { $.config.class-from(.type).box(.delegate, :$!config, |%c) }
-multi method box(::?CLASS:U: Any:D $_, *%c) { $.config.class-from(.type).box(.delegate, |%c) }
+multi method box(::?CLASS:D: Any:D $_, *%c) { (%c<config> //= $.config).class-from(.type).box(.delegate, |%c) }
+multi method box(::?CLASS:U: Any:D $_, *%c) { (%c<config> //  $.config).class-from(.type).box(.delegate, |%c) }
 multi method box(Any:U) { self.WHAT }
 
 #| Node constructor from data


### PR DESCRIPTION
Any config supplied by upstream was previously ignored and class mapping was expected to be done by `LibXML::Node`. This resulted in limited abilities of user code in controlling how boxing is done. See #94.

Note that `LibXML::Node` still does its own class mapping because this is the point of final decision and in many cases it is invoked directly.