### PR TITLE
Re-delegate Node's box method to Config and add caching support

### DIFF
--- a/lib/LibXML/Document.rakumod
+++ b/lib/LibXML/Document.rakumod
@@ -913,7 +913,9 @@ method processXIncludes(LibXML::Config :$config = self.config, |c) is also<proce
 
 #| Returns the element that has an ID attribute with the given value. If no such element exists, this returns LibXML::Element:U.
 method getElementById(Str:D $id --> LibXML::Element) is also<getElementsById> {
-    self.box: LibXML::Element, $.raw.getElementById($id)
+    $.raw.getElementById($id)
+        andthen self.box(LibXML::Element, $_)
+        orelse $.config.class-from(xmlElem)
 }
 =para Note: the ID of an element may change while manipulating the document. For
     documents with a DTD, the information about ID attributes is only available if

--- a/lib/LibXML/Item.rakumod
+++ b/lib/LibXML/Item.rakumod
@@ -49,10 +49,9 @@ multi method box-class(::?CLASS:U: Int:D $id) { LibXML::Config.class-from($id) }
 multi method box-class(::?CLASS:D: Int:D $id) { $!config.class-from($id) }
 
 proto method box(|) {*}
-# XXX Should it be `anyNode:D` instead of `Any:D`??
 multi method box(::?CLASS:D: Any:D $_, *%c) { (%c<config> //= $.config).class-from(.type).box(.delegate, |%c) }
 multi method box(::?CLASS:U: Any:D $_, *%c) { (%c<config> //  $.config).class-from(.type).box(.delegate, |%c) }
-multi method box(Any:U) { self.WHAT }
+multi method box(Any:U \raw-type, :$config) { ($config    //  $.config).box(raw-type, { self.WHAT }) }
 
 #| Node constructor from data
 proto method ast-to-xml(::?CLASS:D: | --> LibXML::Item) {*}

--- a/lib/LibXML/Node.rakumod
+++ b/lib/LibXML/Node.rakumod
@@ -159,15 +159,15 @@ method native is DEPRECATED<raw> { self.raw }
 method domFailure { $.raw.domFailure.Str }
 method string-value { $.raw.string-value.Str }
 
-submethod DESTROY {
-    self.raw.Unreference;
+submethod TWEAK {
+    $!raw.Reference;
 }
 
-multi method box(anyNode:D $node, *%c) {
-    $node.Reference;
-    my $class := (%c<config> //= self.config).class-from($node);
-    $class.bless: :raw($node.delegate), |%c;
+submethod DESTROY {
+    $!raw.Unreference;
 }
+
+multi method box(anyNode:D $node, *%c) { (%c<config> //= self.config).box($node, |%c) }
 
 multi method raku(::?CLASS:D: $obj?) {
     # issue #95


### PR DESCRIPTION
A new config attribute `with-cache` defines if simple caching based on node's `unique-key` should be used.

Method `box` is re-delegated to `LibXML::Config` to allow user code to redefine boxing at the deep levels where control over `LibXML` internals is normally impossible. The point is in allowing a user to fully override the way boxing is done allowing for things like 3rd-party caching, for example.

Also `class-from` now supports mapping from a raw type into a high-level class. This is useful for cases when `$raw.type` is not availabe because `$raw` is a typeobject, but we still need to know what class would be the face of this native representation.